### PR TITLE
Changed to Always use Python 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,6 @@ RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSI
     && rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+RUN python3.8 -m pip install --no-cache-dir -r requirements.txt
 
-ENTRYPOINT [ "python", "./bootstrap.py" ]
+ENTRYPOINT [ "python3.8", "./bootstrap.py" ]


### PR DESCRIPTION
If other versions of python are preinstalled, the pip and python commands may use other versions that are not supported.