### PR TITLE
Prevent crashes on unhandled exceptions with the avatar endpoint.

### DIFF
--- a/dash/routes/avatar.py
+++ b/dash/routes/avatar.py
@@ -15,11 +15,21 @@ opener.addheaders = [('User-agent', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9
 urllib.request.install_opener(opener)
 avatar = Blueprint('avatar', url_prefix='/avatar')
 
+valid_sizes = [
+    60,
+    88,
+    95,
+    120,
+    300,
+    600
+]
 
 @avatar.get('/<penguin_id:int>')
 async def get_avatar(request, penguin_id: int):
     background = request.raw_args.get('photo', 'true')
     size = request.raw_args.get('size', 120)
+    if size not in valid_sizes:
+        return response.json({"message": 'Invalid size'}, status=400)
 
     clothing = await Penguin.select(
         'photo', 'flag', 'color', 'head', 'face', 'body',  'neck', 'hand', 'feet'

--- a/dash/routes/avatar.py
+++ b/dash/routes/avatar.py
@@ -44,8 +44,8 @@ async def get_avatar(request, penguin_id: int):
     loop = asyncio.get_event_loop()
     try:
         image = await loop.run_in_executor(None, build_avatar, clothing, int(size))
-    except Exception as e:
-        return response.json({"message": str(e)}, status=500)
+    except:
+        return response.json({"message": "Something has gone wrong."}, status=500)
     return response.raw(image, headers={'Content-type': 'image/png'})
 
 

--- a/dash/routes/avatar.py
+++ b/dash/routes/avatar.py
@@ -42,7 +42,10 @@ async def get_avatar(request, penguin_id: int):
         clothing.pop(0)
 
     loop = asyncio.get_event_loop()
-    image = await loop.run_in_executor(None, build_avatar, clothing, int(size))
+    try:
+        image = await loop.run_in_executor(None, build_avatar, clothing, int(size))
+    except Exception as e:
+        return response.json({"message": str(e)}, status=500)
     return response.raw(image, headers={'Content-type': 'image/png'})
 
 


### PR DESCRIPTION
Sizes on which clothing items are not available in error, this simple fix returns 400 when an invalid size is passed.

Slightly similar to #10, with the exception of not silently changing the request and handling other possible errors that said pull request would let through.