### PR TITLE
Strip() usernames on signup

### DIFF
--- a/dash/routes/create/legacy.py
+++ b/dash/routes/create/legacy.py
@@ -48,7 +48,7 @@ async def validate_agreement(_, post_data):
 
 
 async def validate_username(request, post_data):
-    username = post_data.get('username', [None])[0]
+    username = post_data.get('username', [None])[0].strip()
     color = post_data.get('colour')[0]
     lang = post_data.get('lang')[0]
 
@@ -103,7 +103,7 @@ async def validate_username(request, post_data):
 async def validate_password_email(request, post_data):
     session_id = post_data.get('sid')[0]
     session = request['session']
-    username = session.get('username', None)
+    username = session.get('username', None).strip()
     color = session.get('color', None)
     password = post_data.get('password')[0]
     password_confirm = post_data.get('password_confirm')[0]

--- a/dash/routes/create/vanilla.py
+++ b/dash/routes/create/vanilla.py
@@ -149,7 +149,7 @@ async def register(request, lang):
     
 
 async def _validate_registration(request, post_data, lang):
-    username = post_data.get('name', [None])[0] 
+    username = post_data.get('name', [None])[0].strip()
     password = post_data.get('pass', [None])[0] 
     email = post_data.get('email', [None])[0]
     color = post_data.get('color', [None])[0]  
@@ -239,7 +239,7 @@ async def _validate_registration(request, post_data, lang):
 
 
 async def _validate_username(request, post_data, lang):
-    username = post_data.get('name', [None])[0] 
+    username = post_data.get('name', [None])[0].strip()
     if not username:
         request['session']['errors']['name'] = True
         return response.json(


### PR DESCRIPTION
**Why?** If you make a username like `[ ]owo` or `owo[ ]` then you can bypass the length limit, or make duplicate accounts (i.e. `daniel` and `daniel[ ]` and `[ ]daniel`).
P.S. I put the spaces in brackets because GitHub doesn't let you start code blocks with a space.
**Why strip and not just say no (check if it ends/starts with a space through regex or similar)?** Because on some devices, autocorrect might put a space at the end and the user doesn't notice, and they wonder why it's telling them they can't sign up.