### PR TITLE
Add predefined versions to sanic and sanic_session for working build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ python-Levenshtein
 fast-autocomplete[levenshtein]
 aiohttp
 aioredis
-sanic
-sanic_session
+sanic==20.12.1
+sanic_session==0.7.3
 sendgrid
 bcrypt
 gino


### PR DESCRIPTION
version 20.12.1 to sanic and version 0.7.3 to sanic_session. Dash cannot build 100% functionally without these changes.