### PR TITLE
Fix loop argument in avatar.py

### DIFF
--- a/dash/routes/avatar.py
+++ b/dash/routes/avatar.py
@@ -50,7 +50,7 @@ async def get_avatar(request, penguin_id: int):
         loop = asyncio.get_event_loop()
         try:
             future = loop.run_in_executor(None, build_avatar, clothing, int(size))
-            image = await asyncio.wait_for(future, timeout=5.0, loop=loop)
+            image = await asyncio.wait_for(future, timeout=5.0)
 
             await app.ctx.redis.setex(f'{penguin_id}.{size}.avatar', cache_expiry, image)
         except asyncio.TimeoutError:


### PR DESCRIPTION
Just installed wand, log into dash manager, and noticed that avatars don't work at all.
Example:
![2022-01-22_20-18](https://user-images.githubusercontent.com/37220313/150649215-c1852102-672a-41f3-81c3-08a13326d973.png)
Error in console:
```
dash_1 | [2022-01-22 17:17:58 +0000] [13] [ERROR] Exception occurred while handling uri: 'http://play.localhost/avatar/101?=120'
dash_1 | Traceback (most recent call last):
dash_1 |   File "handle_request", line 83, in handle_request
dash_1 |     )
dash_1 |   File "/usr/src/dash/dash/routes/avatar.py", line 53, in get_avatar
dash_1 |     image = await asyncio.wait_for(future, timeout=5.0, loop=loop)
dash_1 | TypeError: wait_for() got an unexpected keyword argument 'loop'
```

So, I make an easy fix for this.
Seems to work:
![2022-01-22_20-20](https://user-images.githubusercontent.com/37220313/150649311-4a8db64d-0e2c-4bcc-ba22-66921f04845f.png)


