### PR TITLE
Update Dockerfile to specify python version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3.9-alpine
 
 RUN apk add \
     openssl \


### PR DESCRIPTION
Specifies python version for the alpine image, as current versions of python do not correctly build needed modules in requirements.txt